### PR TITLE
user receives message if ingredient substitutions are not found

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -307,6 +307,14 @@ let displayIngredientSubstitutions = (substitutions) => {
     })
 };
 
+let displayNoIngredientSubstitutions = () => {
+    let ingredientSubstitutionContainer = document.querySelector('.ingredient-substitutions');
+    let noSubstitutionsMessageContainer = document.createElement('p');
+    let noSubstitutionsMessage = 'Could not find any substitutions for that ingredient.'
+    noSubstitutionsMessageContainer.textContent = noSubstitutionsMessage;
+    ingredientSubstitutionContainer.appendChild(noSubstitutionsMessageContainer);
+}
+
 let getSubstituteIngredients = (event) => {
     event.preventDefault();
     let localStorageToken = localStorage.getItem("token");
@@ -320,7 +328,11 @@ let getSubstituteIngredients = (event) => {
     }).then((contents) => {
         return contents.json();
     }).then((results) => {
-        displayIngredientSubstitutions(results.substitutes);    
+        if (results.status === 'failure') {
+            displayNoIngredientSubstitutions();
+        } else {
+            displayIngredientSubstitutions(results.substitutes);    
+        }
     })
 };
 


### PR DESCRIPTION
User will now receive a message indicating substitution ingredients were not found in their search. No longer receiving an error message. @hglasser @TRACYMUSIKER can you please review when you get a chance? Thank you!